### PR TITLE
Initial work on shouldAccept

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,25 @@ $throttle->throttle('api.request', 1000, 86400000);
 
 ```
 
+If you would rather the library tell you that the request exceeds the specified threshold instead call:
+
+``` php
+$throttle = new Stiphle\Throttle\LeakyBucket;
+if ($estimate = $throttle->shouldAccept('switcher.global', 25, 60 * 1000 !== true)) {
+    header("Content-Type: application/json");
+    header("Retry-After: ".$estimate);
+    http_response_code(429);
+    exit;
+}
+
+
+```
+
+
 __NB:__ The current implementation of the `TimeWindow` throttle will only work on 64-bit architectures!
+
+__NB:__ Note the type sensitive comparison with `shouldAccept`, as positive integers indicating the numnber of ms before
+a successfull request can be initiated will cast to `TRUE`.
 
 Storage
 -------

--- a/src/Stiphle/Throttle/LeakyBucket.php
+++ b/src/Stiphle/Throttle/LeakyBucket.php
@@ -45,7 +45,7 @@ class LeakyBucket implements ThrottleInterface
      * Pass this function a key to describe the resource, and the $limit of requests against that in $miliseconds. If
      * that limit has been exceeded the function will wait until the request can be fufilled before continuing.
      *
-     * This function waits until the request can be satisfied. 
+     * This function waits until the request can be satisfied.
      *
      * @param string $key  - A unique key for what we're throttling
      * @param int $limit   - How many are allowed
@@ -96,11 +96,11 @@ class LeakyBucket implements ThrottleInterface
          * Try and do our waiting without a lock
          */
         $key = $this->getStorageKey($key, $limit, $milliseconds);
-        $return   = true;
+        $shouldAccept   = true;
         $newRatio = $this->getNewRatio($key, $limit, $milliseconds);
 
         if ($newRatio > $milliseconds) {
-            $return = false;
+            $shouldAccept = false;
         }
 
         /**
@@ -111,7 +111,7 @@ class LeakyBucket implements ThrottleInterface
         $this->setLastRatio($key, $newRatio);
         $this->setLastRequest($key, microtime(1));
         $this->storage->unlock($key);
-        return $return;
+        return $shouldAccept;
     }
 
     /**


### PR DESCRIPTION
Hi Dave!

I found your library while looking for something simple to handle some throttling in an app I'm working on. Unfortunately my needs differ a bit from what the app offers, I'd rather reject incoming requests that pass my throttling threshold, rather than wait for them to become permissible.

This PR adds a copy/pasta version of the `throttle` function called `shouldAccept` that never waits, it only tells the calling code that the request should be rejected. Usage would be something like:

```
        //Global Throttle
        if (!$throttle->shouldAccept('switcher.global', 25, 60 * 1000)) {
            header("Content-Type: application/json");
            echo json_encode(["result"=> "unknown", "error" => "throttled"]);
            http_response_code(429);
            exit;
        }
```

Is adding this feature conceptually interesting to the project for you? If so I'll clean this up for a real PR.


thanks